### PR TITLE
Removing default cayman theme

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,1 +1,0 @@
-theme: jekyll-theme-cayman


### PR DESCRIPTION
This file was gen'ed by GH when I selected docs/ to be the default